### PR TITLE
增加一个选项用于在生成的RouterLoad中用Activity的Class替换原className的string

### DIFF
--- a/drouter-api/src/main/java/com/didi/drouter/router/RouterDispatcher.java
+++ b/drouter-api/src/main/java/com/didi/drouter/router/RouterDispatcher.java
@@ -46,7 +46,13 @@ class RouterDispatcher {
         Intent intent = meta.getIntent();
         if (intent == null) {
             intent = new Intent();
-            intent.setClassName(context, meta.getActivityClassName());
+            Class<?> routerClass = meta.getRouterClass();
+            // 如果有class优先使用class
+            if (routerClass != null) {
+                intent.setClass(context, routerClass);
+            } else {
+                intent.setClassName(context, meta.getActivityClassName());
+            }
         }
         if (request.getExtra().containsKey(Extend.START_ACTIVITY_FLAGS)) {
             intent.setFlags(request.getInt(Extend.START_ACTIVITY_FLAGS));

--- a/drouter-plugin-proxy/src/main/groovy/com/didi/drouter/plugin/RouterSetting.groovy
+++ b/drouter-plugin-proxy/src/main/groovy/com/didi/drouter/plugin/RouterSetting.groovy
@@ -10,5 +10,6 @@ class RouterSetting {
     boolean incremental = true
     boolean cache = true
     boolean supportNoAnnotationActivity = false
+    boolean useActivityRouterClass = false
     String pluginName
 }

--- a/drouter-plugin/src/main/groovy/com/didi/drouter/generator/RouterCollect.java
+++ b/drouter-plugin/src/main/groovy/com/didi/drouter/generator/RouterCollect.java
@@ -1,6 +1,7 @@
 package com.didi.drouter.generator;
 
 import com.didi.drouter.annotation.Router;
+import com.didi.drouter.plugin.RouterProperties;
 import com.didi.drouter.plugin.RouterSetting;
 import com.didi.drouter.utils.Logger;
 import com.didi.drouter.utils.StoreUtil;
@@ -163,7 +164,12 @@ class RouterCollect extends AbsRouterCollect {
                 metaBuilder.append("\"").append(pathValue).append("\"");
                 metaBuilder.append(",");
                 if ("com.didi.drouter.store.RouterMeta.ACTIVITY".equals(type)) {
-                    metaBuilder.append("\"").append(routerCc.getName()).append("\"");
+                    // !setting.getUseActivityRouterClass()
+                    if (!RouterProperties.useActivityRouterClass) {
+                        metaBuilder.append("\"").append(routerCc.getName()).append("\"");
+                    } else {
+                        metaBuilder.append(routerCc.getName()).append(".class");
+                    }
                 } else {
                     metaBuilder.append(routerCc.getName()).append(".class");
                 }

--- a/drouter-plugin/src/main/groovy/com/didi/drouter/plugin/RouterProperties.java
+++ b/drouter-plugin/src/main/groovy/com/didi/drouter/plugin/RouterProperties.java
@@ -1,0 +1,36 @@
+package com.didi.drouter.plugin;
+
+import org.gradle.api.Project;
+
+/**
+ * temporary global access "gradle.properties".
+ * (If don't upgrade plugin version for [RouterSetting])
+ *
+ * Created by holmes on 2021/10/7
+ */
+public class RouterProperties {
+
+    private RouterProperties() {
+    }
+
+    public static boolean getBoolean(Project project, String key) {
+        Object obj = project.getProperties().get(key);
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof String) {
+            return Boolean.parseBoolean((String) obj);
+        } else if (obj instanceof Boolean) {
+            return (Boolean) obj;
+        }
+        return false;
+    }
+
+    /**
+     * key: "drouter.useActivityRouterClass"
+     *
+     */
+    public static boolean useActivityRouterClass = false;
+
+
+}

--- a/drouter-plugin/src/main/groovy/com/didi/drouter/plugin/RouterSetting.groovy
+++ b/drouter-plugin/src/main/groovy/com/didi/drouter/plugin/RouterSetting.groovy
@@ -9,5 +9,6 @@ class RouterSetting {
     boolean incremental = true
     boolean cache = true
     boolean supportNoAnnotationActivity = false
+    boolean useActivityRouterClass = false
     String pluginName
 }

--- a/drouter-plugin/src/main/groovy/com/didi/drouter/plugin/RouterTask.java
+++ b/drouter-plugin/src/main/groovy/com/didi/drouter/plugin/RouterTask.java
@@ -67,6 +67,10 @@ public class RouterTask {
     void run() {
         StoreUtil.clear();
         JarUtils.printVersion(project, compileClassPath);
+
+        RouterProperties.useActivityRouterClass = RouterProperties.getBoolean(project, "drouter.useActivityRouterClass");
+        Logger.d("load drouter properties: drouter.useActivityRouterClass=" + RouterProperties.useActivityRouterClass);
+
         pool = new ClassPool();
         classClassify = new ClassClassify(pool, setting);
         startExecute();
@@ -83,7 +87,7 @@ public class RouterTask {
             } else {
                 loadFullPaths(compileClassPath);
             }
-            Logger.d("load class used: " + (System.currentTimeMillis() - timeStart)  + "ms");
+            Logger.d("load class used: " + (System.currentTimeMillis() - timeStart) + "ms");
             timeStart = System.currentTimeMillis();
             classClassify.generatorRouter(routerDir);
             Logger.d("generator router table used: " + (System.currentTimeMillis() - timeStart) + "ms");
@@ -257,6 +261,6 @@ public class RouterTask {
         }
         return file;
     }
-    
+
 
 }


### PR DESCRIPTION
针对有会在打包时对Activity做动态修改的特殊需求（打包后的Activity类名和coding时类名是不一样的）。

所以增加一个选项，可以在生成的DRouter类中直接使用Class。避免Activity 修改后，原String类型的className找不到最终的Activity类（因为类名改了）。

由于改drouter参数要升级plugin。所以临时用"gradle.properties"文件的方式来做配置。
key为“drouter.useActivityRouterClass”
